### PR TITLE
#37 REST API - Add Keycloak authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,16 @@ To be able to run the tests (since some of the tests are dependent on the databa
 In IntelliJ, for the `Tests in 'banking-kata.test'` configuration, you can copy this into the `Environment variables`
 
 ```
-POSTGRES_URL=jdbc:postgresql://localhost:5432/banking_kata;POSTGRES_USER=postgres;POSTGRES_PASSWORD=admin
+POSTGRES_URL=jdbc:postgresql://localhost:5432/banking_kata;POSTGRES_USER=postgres;POSTGRES_PASSWORD=admin;
+KEYCLOAK_REALM_URL=http://localhost:10000/auth/realms/banking-kata;KEYCLOAK_TEST_CLIENT_ID=test-client;
+KEYCLOAK_TEST_CLIENT_SECRET=XXXX
 ```
 
 You need to have created the database, in the example I had created a database called `banking_kata`. 
+
+Also, you need to have created a keycloak realm with client_credentials flow enabled.
+
+In the example I had created a realm called `banking-kata` with a client_id `test-client`.
 
 Please update the environment variable values based on your local settings.
 
@@ -45,6 +51,9 @@ Environment Variables
 $env:POSTGRES_URL='jdbc:postgresql://localhost:5432/banking_kata'
 $env:POSTGRES_USER='postgres'
 $env:POSTGRES_PASSWORD='admin'
+$env:KEYCLOAK_REALM_URL='http://localhost:10000/auth/realms/banking-kata'
+$env:KEYCLOAK_TEST_CLIENT_ID='test-client'
+$env:KEYCLOAK_TEST_CLIENT_SECRET='XXXX'
 ```
 
 Running build with automated tests:

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.0'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server:2.7.3'
     implementation 'de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.3.0'
     implementation 'net.sizovs:pipelinr:0.7'
     implementation 'de.mkammerer.snowflake-id:snowflake-id:0.0.1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,44 @@ services:
     restart: always
     environment:
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_PASSWORD=admin
     ports:
       - '5432:5432'
+    networks:
+      - local
     volumes:
       - db:/var/lib/postgresql/data
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - '9000:8080'
+    networks:
+      - local
+    depends_on:
+      - db
+
+  keycloak:
+    image: jboss/keycloak:16.1.1
+    container_name: keycloak
+    environment:
+      - DB_VENDOR=postgres
+      - DB_ADDR=db
+      - DB_DATABASE=keycloak
+      - DB_USER=postgres
+      - DB_PASSWORD=admin
+    ports:
+      - "10000:8080"
+    restart: unless-stopped
+    networks:
+      - local
+    depends_on:
+      - db
+
 volumes:
   db:
     driver: local
+
+networks:
+  local:

--- a/set_env_var.sh
+++ b/set_env_var.sh
@@ -4,3 +4,6 @@ export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=admin
 export POSTGRES_DB=banking_kata
 export POSTGRES_URL=jdbc:postgresql://localhost:5432/$POSTGRES_DB;POSTGRES_USER=$POSTGRES_USER;POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+export KEYCLOAK_REALM_URL=http://localhost:10000/auth/realms/banking-kata
+export KEYCLOAK_TEST_CLIENT_ID=test-client
+export KEYCLOAK_TEST_CLIENT_SECRET=XXXX

--- a/src/main/java/com/optivem/kata/banking/adapters/driver/web/configurations/SecurityConfiguration.java
+++ b/src/main/java/com/optivem/kata/banking/adapters/driver/web/configurations/SecurityConfiguration.java
@@ -1,0 +1,37 @@
+package com.optivem.kata.banking.adapters.driver.web.configurations;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+
+    private final String jwkSetUri;
+
+    public SecurityConfiguration(
+        @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}") String jwtSetUri) {
+        this.jwkSetUri = jwtSetUri;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http.csrf()
+            .disable()
+            .authorizeRequests()
+            .anyRequest()
+            .authenticated()
+            .and()
+            .oauth2ResourceServer()
+            .jwt()
+            .decoder(NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build());
+
+        return http.build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,13 @@ spring:
     password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_REALM_URL}
+          jwk-set-uri: ${KEYCLOAK_REALM_URL}/protocol/openid-connect/certs
+
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQL82Dialect
     show-sql: false

--- a/src/test/java/com/optivem/kata/banking/system/BankAccountControllerSystemTest.java
+++ b/src/test/java/com/optivem/kata/banking/system/BankAccountControllerSystemTest.java
@@ -1,31 +1,70 @@
 package com.optivem.kata.banking.system;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.optivem.kata.banking.core.ports.driver.accounts.openaccount.OpenAccountResponse;
 import com.optivem.kata.banking.core.ports.driver.accounts.viewaccount.ViewAccountResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
 
 import static com.optivem.kata.banking.core.common.builders.requests.OpenAccountRequestBuilder.openAccountRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
 @ContextConfiguration
 class BankAccountControllerSystemTest {
 
-    @Autowired
-    private WebTestClient client;
+    private final WebTestClient client;
+    private final String tokenUri;
+    private final MultiValueMap<String, String> tokenRequestData;
+
+    public BankAccountControllerSystemTest(
+        @Autowired WebTestClient client,
+        @Value("${token-uri}") String tokenUri,
+        @Value("${client-id}") String clientId,
+        @Value("${client-secret}") String clientSecret) {
+
+        this.client = client;
+        this.tokenUri = tokenUri;
+        tokenRequestData = new LinkedMultiValueMap<>();
+
+        tokenRequestData.add("client_id", clientId);
+        tokenRequestData.add("client_secret", clientSecret);
+        tokenRequestData.add("grant_type", "client_credentials");
+    }
+
+    private String getToken() {
+        return "Bearer "
+            + client
+            .post()
+            .uri(tokenUri)
+            .body(BodyInserters.fromFormData(tokenRequestData))
+            .exchange()
+            .returnResult(JsonNode.class)
+            .getResponseBody()
+            .map(tokenResponse -> tokenResponse.get("access_token").textValue())
+            .blockFirst();
+    }
 
     @Test
     void should_open_account_given_valid_request() {
         var request = openAccountRequest().build();
 
-        var response = client.post()
+        var response =
+            client
+                .post()
                 .uri("bank-accounts")
+                .header("Authorization", getToken())
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .accept(MediaType.APPLICATION_JSON)
@@ -41,8 +80,11 @@ class BankAccountControllerSystemTest {
 
         var accountNumber = response.getAccountNumber();
 
-        var viewResponse = client.get()
+        var viewResponse =
+            client
+                .get()
                 .uri("bank-accounts/" + accountNumber)
+                .header("Authorization", getToken())
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,3 @@
+token-uri: ${KEYCLOAK_REALM_URL}/protocol/openid-connect/token
+client-id: ${KEYCLOAK_TEST_CLIENT_ID}
+client-secret: ${KEYCLOAK_TEST_CLIENT_SECRET}


### PR DESCRIPTION
Changes:
- Configure Spring Security to use Keycloak as authorization server.
- Modify `docker-compose` to use jboss Keycloak and adminer (for visualize database tables) images.
- Modify `application.yml` and `application-test.yml` to use new env vars.
- Modify `BankAccountControllerSystemTest` to use new Keycloak authentication.